### PR TITLE
feat: Transform your GitHub profile README into a developer showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,158 @@
-### 0xWulf
+<div align="center">
 
-B.A. Computer Science student at the International University of Applied Sciences (IU Germany).  
-Focused on Linux-first workflows and modern Java, with a strong interest in full-stack TypeScript.
+# Hey there! I'm 0xWulf 👋
 
----
+### 🎓 CS Student | 🐧 Linux Enthusiast | 💻 Full-Stack Developer
 
-#### Selected Projects
+*Building modern web applications with clean code and great UX*
 
-- **[Reading-Habit-Tracker](https://github.com/hexawulf/reading-habit-tracker)**  
-  Turns a Goodreads CSV export into interactive dashboards that surface personal reading trends.  
-  **Stack:** React + React Router, Recharts, Node.js / Express, CSV Parser, Day.js.
+[![Portfolio](https://img.shields.io/badge/🌐_Portfolio-0xwulf.dev-blue?style=for-the-badge)](https://0xwulf.dev)
+[![Email](https://img.shields.io/badge/📧_Email-dev@0xwulf.dev-red?style=for-the-badge)](mailto:dev@0xwulf.dev)
+[![GitHub](https://img.shields.io/badge/GitHub-Follow-black?style=for-the-badge&logo=github)](https://github.com/hexawulf)
 
-- **[TableTamer](https://github.com/hexawulf/tabletamer)**  
-  A browser-based CSV visualizer that converts raw data into filterable, editable tables—no back end required.  
-  **Stack:** React 18, TypeScript, Vite, Tailwind CSS + shadcn/ui, PapaParse, FileSaver.js.
-
-- **[CodePatchwork](https://github.com/hexawulf/CodePatchwork)**  
-  Pinterest-style code-snippet manager with Google/Firebase auth, full-text search, and shareable boards.  
-  **Stack:** React + Tailwind, TypeScript, Node.js API, PostgreSQL, Firebase Authentication.
+</div>
 
 ---
 
-#### What I’m Working On
+## 🚀 About Me
 
-- Optimizing Java tooling for Linux desktops.  
-- Building developer-centric web apps with clean UI/UX and robust back ends.  
-- Exploring containerized deployments on Raspberry Pi.
+🎓 **B.A. Computer Science** student at International University of Applied Sciences (IU Germany)  
+🐧 **Linux-first workflows** advocate and Java optimization enthusiast  
+💻 **Full-stack TypeScript** developer with a passion for clean, scalable code  
+🎯 **Focus**: Building developer-centric tools that solve real problems  
 
 ---
 
-#### Let’s Connect
+## 🛠️ Featured Projects
 
-Open an issue, start a discussion, or reach me at **dev@0xwulf.dev**—I’m always up for constructive feedback or collaboration.
+<table>
+<tr>
+<td width="50%">
+
+### 📊 [Reading-Habit-Tracker](https://github.com/hexawulf/reading-habit-tracker)
+*Transform Goodreads data into beautiful insights*
+
+**🚀 [Live Demo](https://mybooks.piapps.dev) | 📂 [Source](https://github.com/hexawulf/reading-habit-tracker)**
+
+Interactive dashboards that surface personal reading trends from Goodreads CSV exports.
+
+**Tech Stack:** React • Recharts • Node.js • Express • CSV Parser
+
+![Reading Tracker](https://img.shields.io/badge/📈_Live_Demo-mybooks.piapps.dev-success?style=flat-square)
+
+</td>
+<td width="50%">
+
+### 📋 [TableTamer](https://github.com/hexawulf/tabletamer)
+*Browser-based CSV visualizer and editor*
+
+**🚀 [Live Demo](https://tabletamer.piapps.dev) | 📂 [Source](https://github.com/hexawulf/tabletamer)**
+
+Convert raw CSV data into filterable, editable tables with zero backend dependency.
+
+**Tech Stack:** React 18 • TypeScript • Vite • Tailwind • shadcn/ui
+
+![Table Tamer](https://img.shields.io/badge/🔧_Live_Demo-tabletamer.piapps.dev-blue?style=flat-square)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="center">
+
+### 🧩 [CodePatchwork](https://github.com/hexawulf/CodePatchwork)
+*Pinterest-style code snippet manager*
+
+**🚀 [Live Demo](https://codepatchwork.com) | 📂 [Source](https://github.com/hexawulf/CodePatchwork)**
+
+Visual code snippet organization with Firebase auth, full-text search, and public sharing capabilities.
+
+**Tech Stack:** React • Tailwind • TypeScript • Node.js • PostgreSQL • Firebase
+
+![CodePatchwork](https://img.shields.io/badge/🎨_Live_Demo-codepatchwork.com-purple?style=flat-square)
+
+</td>
+</tr>
+</table>
+
+---
+
+## 📊 GitHub Stats
+
+<div align="center">
+
+<img height="180em" src="https://github-readme-stats.vercel.app/api?username=hexawulf&show_icons=true&theme=dark&include_all_commits=true&count_private=true"/>
+<img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=hexawulf&layout=compact&langs_count=8&theme=dark"/>
+
+</div>
+
+---
+
+## 💻 Tech Stack & Skills
+
+### **Languages**
+![Java](https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=java&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+
+### **Frontend**
+![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![TailwindCSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=for-the-badge&logo=tailwind-css&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+
+### **Backend & Database**
+![Node.js](https://img.shields.io/badge/Node.js-43853D?style=for-the-badge&logo=node.js&logoColor=white)
+![Express.js](https://img.shields.io/badge/Express.js-404D59?style=for-the-badge)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)
+
+### **Tools & Platforms**
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+![Firebase](https://img.shields.io/badge/Firebase-039BE5?style=for-the-badge&logo=Firebase&logoColor=white)
+
+---
+
+## 🔭 Current Focus
+
+🔧 **Java Tooling Optimization** - Enhancing development workflows on Linux desktops  
+🌐 **Developer-Centric Web Apps** - Building tools with exceptional UI/UX and robust backends  
+🐳 **Containerized Deployments** - Exploring Docker solutions on Raspberry Pi infrastructure  
+📚 **Learning Journey** - Diving deeper into system architecture and performance optimization  
+
+---
+
+## 📈 Contribution Activity
+
+<div align="center">
+
+![GitHub Activity Graph](https://github-readme-activity-graph.vercel.app/graph?username=hexawulf&theme=react-dark&hide_border=true)
+
+</div>
+
+---
+
+## 🤝 Let's Build Something Amazing Together!
+
+<div align="center">
+
+**Ready to collaborate on innovative projects?**
+
+[![Email Me](https://img.shields.io/badge/📧_Email_Me-dev@0xwulf.dev-blue?style=for-the-badge)](mailto:dev@0xwulf.dev)
+[![Start Discussion](https://img.shields.io/badge/💬_Start_Discussion-GitHub-black?style=for-the-badge&logo=github)](https://github.com/hexawulf/hexawulf/discussions)
+[![Open Issue](https://img.shields.io/badge/🐛_Report_Issue-GitHub-red?style=for-the-badge&logo=github)](https://github.com/hexawulf/hexawulf/issues)
+
+*I'm always excited about constructive feedback, collaboration opportunities, and innovative project ideas!*
+
+</div>
+
+---
+
+<div align="center">
+
+**🐺 "Code with purpose, build with passion"**
+
+![Profile Views](https://komarev.com/ghpvc/?username=hexawulf&color=blue&style=flat-square)
+[![GitHub followers](https://img.shields.io/github/followers/hexawulf?label=Follow&style=social)](https://github.com/hexawulf)
+
+*Thanks for visiting! ⭐ Star my repos if you find them useful*
+
+</div>


### PR DESCRIPTION
This commit completely revamps your GitHub profile README to create a more engaging, visually appealing, and informative developer showcase.

Key changes include:
- Added a dynamic header with contact badges.
- Enhanced the "About Me" section with more personality.
- Overhauled the "Featured Projects" section to prominently display live demo links for TableTamer, Reading-Habit-Tracker, and CodePatchwork, using a table layout for better visual organization.
- Integrated GitHub Stats and Top Languages sections.
- Added a comprehensive "Tech Stack & Skills" section with badges.
- Updated the "Current Focus" section for better engagement.
- Included a GitHub activity graph.
- Transformed the contact section into a strong call-to-action.
- Added a fun footer with profile views and follower count.

The update addresses all requirements from the issue, focusing on making live demo links highly visible and improving the overall professional branding and visual appeal of your profile.